### PR TITLE
GH action updated to remove node js depreciation warnings

### DIFF
--- a/.github/workflows/generate_newsletter.yml
+++ b/.github/workflows/generate_newsletter.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/README.md
+++ b/README.md
@@ -78,4 +78,3 @@ Some things that can be further improved
 
 - **Event grid**. In the moment the width of the grid is somehow set to auto. So depending on the Event description size, the blue box for calendar and date change the size. It would better find a better layout definition
 - **Jinja2 GH Action?** I created a very standard python script for using jinja2. It should exist some equivalent GitHub Action to do this without the python script.
-- **GH Action Warning:** Note.js is dreprecated, so it is necessary update the GH Action.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ Some things that can be further improved
 
 - **Event grid**. In the moment the width of the grid is somehow set to auto. So depending on the Event description size, the blue box for calendar and date change the size. It would better find a better layout definition
 - **Jinja2 GH Action?** I created a very standard python script for using jinja2. It should exist some equivalent GitHub Action to do this without the python script.
+- GH action fails if the html has not been changed in the commit. Not a huge problem but annoying.

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 title: "Title"
 heading: "Short heading"
-body: "This is the body of the advertising. Here you can put any information you want."
+body: "This is the body of the advertisment. You can put any information you want here."
 
 events:
   - title: "Event 1"
@@ -9,7 +9,7 @@ events:
     tags:
       - "tag1"
       - "tag2"
-    summary: "This is a summary of the event 1."
+    summary: "This is a summary of event 1."
     url: "https://example.com/event1"
     
   - title: "Event 2"
@@ -20,6 +20,6 @@ events:
       - "tag3"
       - "tag4"
       - "tag5"
-    summary: "This is a summary of the event 2."
+    summary: "This is a summary of event 2."
     url: "https://example.com/event2"
     

--- a/newsletter.html
+++ b/newsletter.html
@@ -210,7 +210,7 @@
                     <tr>
                      <td valign="top" align="center" style="padding: 0px 0px 0px 0px;">
                       <div class="pc-font-alt" style="line-height: 150%; letter-spacing: -0px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 16px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: center; text-align-last: center;">
-                       <div><span style="font-weight: 300;font-style: normal;">This is the body of the advertising. Here you can put any information you want.</span>
+                       <div><span style="font-weight: 300;font-style: normal;">This is the body of the advertisment. You can put any information you want here.</span>
                        </div>
                       </div>
                      </td>
@@ -394,7 +394,7 @@
                                 <tr>
                                  <td valign="top" align="left">
                                   <div class="pc-font-alt" style="line-height: 21px; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #333333; text-align: left; text-align-last: left;">
-                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of the event 1.</span>
+                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of event 1.</span>
                                    </div>
                                   </div>
                                  </td>
@@ -623,7 +623,7 @@
                                 <tr>
                                  <td valign="top" align="left">
                                   <div class="pc-font-alt" style="line-height: 21px; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #333333; text-align: left; text-align-last: left;">
-                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of the event 2.</span>
+                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of event 2.</span>
                                    </div>
                                   </div>
                                  </td>

--- a/newsletter.html
+++ b/newsletter.html
@@ -1,0 +1,949 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="https://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+ <meta charset="UTF-8" />
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+ <!--[if !mso]><!-- -->
+ <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+ <!--<![endif]-->
+ <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+ <meta name="format-detection" content="telephone=no" />
+ <meta name="format-detection" content="date=no" />
+ <meta name="format-detection" content="address=no" />
+ <meta name="format-detection" content="email=no" />
+ <meta name="x-apple-disable-message-reformatting" />
+ <link href="https://fonts.googleapis.com/css?family=Inter:ital,wght@0,300;0,400;0,500" rel="stylesheet" />
+ <link href="https://fonts.googleapis.com/css?family=Paytone+One:ital,wght@0,400;0,400" rel="stylesheet" />
+ <title>Event</title>
+ <!-- Made with Postcards by Designmodo https://designmodo.com/postcards -->
+ <style>
+ html,
+         body {
+             margin: 0 !important;
+             padding: 0 !important;
+             min-height: 100% !important;
+             width: 100% !important;
+             -webkit-font-smoothing: antialiased;
+         }
+ 
+         * {
+             -ms-text-size-adjust: 100%;
+         }
+ 
+         #outlook a {
+             padding: 0;
+         }
+ 
+         .ReadMsgBody,
+         .ExternalClass {
+             width: 100%;
+         }
+ 
+         .ExternalClass,
+         .ExternalClass p,
+         .ExternalClass td,
+         .ExternalClass div,
+         .ExternalClass span,
+         .ExternalClass font {
+             line-height: 100%;
+         }
+ 
+         table,
+         td,
+         th {
+             mso-table-lspace: 0 !important;
+             mso-table-rspace: 0 !important;
+             border-collapse: collapse;
+         }
+ 
+         u + .body table, u + .body td, u + .body th {
+             will-change: transform;
+         }
+ 
+         body, td, th, p, div, li, a, span {
+             -webkit-text-size-adjust: 100%;
+             -ms-text-size-adjust: 100%;
+             mso-line-height-rule: exactly;
+         }
+ 
+         img {
+             border: 0;
+             outline: 0;
+             line-height: 100%;
+             text-decoration: none;
+             -ms-interpolation-mode: bicubic;
+         }
+ 
+         a[x-apple-data-detectors] {
+             color: inherit !important;
+             text-decoration: none !important;
+         }
+ 
+         .pc-gmail-fix {
+             display: none;
+             display: none !important;
+         }
+ 
+         @media (min-width: 621px) {
+             .pc-lg-hide {
+                 display: none;
+             } 
+ 
+             .pc-lg-bg-img-hide {
+                 background-image: none !important;
+             }
+         }
+ </style>
+ <style>
+ @media (max-width: 620px) {
+ .pc-project-body {min-width: 0px !important;}
+ .pc-project-container {width: 100% !important;}
+ .pc-sm-hide {display: none !important;}
+ .pc-sm-bg-img-hide {background-image: none !important;}
+ .pc-w620-padding-20-0-20-0 {padding: 20px 0px 20px 0px !important;}
+ .pc-w620-width-140 {width: 140px !important;}
+ .pc-w620-height-auto {height: auto !important;}
+ .pc-w620-fontSize-16 {font-size: 16px !important;}
+ .pc-w620-lineHeight-26 {line-height: 26px !important;}
+ table.pc-w620-spacing-0-0-4-0 {margin: 0px 0px 4px 0px !important;}
+ td.pc-w620-spacing-0-0-4-0,th.pc-w620-spacing-0-0-4-0{margin: 0 !important;padding: 0px 0px 4px 0px !important;}
+ .pc-w620-padding-0-0-0-0 {padding: 0px 0px 0px 0px !important;}
+ .pc-w620-fontSize-36px {font-size: 36px !important;}
+ .pc-w620-lineHeight-40 {line-height: 40px !important;}
+ table.pc-w620-spacing-0-0-16-0 {margin: 0px 0px 16px 0px !important;}
+ td.pc-w620-spacing-0-0-16-0,th.pc-w620-spacing-0-0-16-0{margin: 0 !important;padding: 0px 0px 16px 0px !important;}
+ .pc-w620-padding-0-32-0-32 {padding: 0px 32px 0px 32px !important;}
+ .pc-w620-padding-40-0-0-0 {padding: 40px 0px 0px 0px !important;}
+ table.pc-w620-spacing-0-0-0-0 {margin: 0px 0px 0px 0px !important;}
+ td.pc-w620-spacing-0-0-0-0,th.pc-w620-spacing-0-0-0-0{margin: 0 !important;padding: 0px 0px 0px 0px !important;}
+ .pc-w620-itemsSpacings-0-30 {padding-left: 0px !important;padding-right: 0px !important;padding-top: 15px !important;padding-bottom: 15px !important;}
+ .pc-w620-padding-40-30-40-30 {padding: 40px 30px 40px 30px !important;}
+ 
+ .pc-w620-gridCollapsed-1 > tbody,.pc-w620-gridCollapsed-1 > tbody > tr,.pc-w620-gridCollapsed-1 > tr {display: inline-block !important;}
+ .pc-w620-gridCollapsed-1.pc-width-fill > tbody,.pc-w620-gridCollapsed-1.pc-width-fill > tbody > tr,.pc-w620-gridCollapsed-1.pc-width-fill > tr {width: 100% !important;}
+ .pc-w620-gridCollapsed-1.pc-w620-width-fill > tbody,.pc-w620-gridCollapsed-1.pc-w620-width-fill > tbody > tr,.pc-w620-gridCollapsed-1.pc-w620-width-fill > tr {width: 100% !important;}
+ .pc-w620-gridCollapsed-1 > tbody > tr > td,.pc-w620-gridCollapsed-1 > tr > td {display: block !important;width: auto !important;padding-left: 0 !important;padding-right: 0 !important;}
+ .pc-w620-gridCollapsed-1.pc-width-fill > tbody > tr > td,.pc-w620-gridCollapsed-1.pc-width-fill > tr > td {width: 100% !important;}
+ .pc-w620-gridCollapsed-1.pc-w620-width-fill > tbody > tr > td,.pc-w620-gridCollapsed-1.pc-w620-width-fill > tr > td {width: 100% !important;}
+ .pc-w620-gridCollapsed-1 > tbody > .pc-grid-tr-first > .pc-grid-td-first,pc-w620-gridCollapsed-1 > .pc-grid-tr-first > .pc-grid-td-first {padding-top: 0 !important;}
+ .pc-w620-gridCollapsed-1 > tbody > .pc-grid-tr-last > .pc-grid-td-last,pc-w620-gridCollapsed-1 > .pc-grid-tr-last > .pc-grid-td-last {padding-bottom: 0 !important;}
+ 
+ .pc-w620-gridCollapsed-0 > tbody > .pc-grid-tr-first > td,.pc-w620-gridCollapsed-0 > .pc-grid-tr-first > td {padding-top: 0 !important;}
+ .pc-w620-gridCollapsed-0 > tbody > .pc-grid-tr-last > td,.pc-w620-gridCollapsed-0 > .pc-grid-tr-last > td {padding-bottom: 0 !important;}
+ .pc-w620-gridCollapsed-0 > tbody > tr > .pc-grid-td-first,.pc-w620-gridCollapsed-0 > tr > .pc-grid-td-first {padding-left: 0 !important;}
+ .pc-w620-gridCollapsed-0 > tbody > tr > .pc-grid-td-last,.pc-w620-gridCollapsed-0 > tr > .pc-grid-td-last {padding-right: 0 !important;}
+ 
+ .pc-w620-tableCollapsed-1 > tbody,.pc-w620-tableCollapsed-1 > tbody > tr,.pc-w620-tableCollapsed-1 > tr {display: block !important;}
+ .pc-w620-tableCollapsed-1.pc-width-fill > tbody,.pc-w620-tableCollapsed-1.pc-width-fill > tbody > tr,.pc-w620-tableCollapsed-1.pc-width-fill > tr {width: 100% !important;}
+ .pc-w620-tableCollapsed-1.pc-w620-width-fill > tbody,.pc-w620-tableCollapsed-1.pc-w620-width-fill > tbody > tr,.pc-w620-tableCollapsed-1.pc-w620-width-fill > tr {width: 100% !important;}
+ .pc-w620-tableCollapsed-1 > tbody > tr > td,.pc-w620-tableCollapsed-1 > tr > td {display: block !important;width: auto !important;}
+ .pc-w620-tableCollapsed-1.pc-width-fill > tbody > tr > td,.pc-w620-tableCollapsed-1.pc-width-fill > tr > td {width: 100% !important;box-sizing: border-box !important;}
+ .pc-w620-tableCollapsed-1.pc-w620-width-fill > tbody > tr > td,.pc-w620-tableCollapsed-1.pc-w620-width-fill > tr > td {width: 100% !important;box-sizing: border-box !important;}
+ }
+ </style>
+ <style>
+ @media all { @font-face { font-family: 'Inter'; font-style: normal; font-weight: 300; src: url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfAZFhjg.woff') format('woff'), url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfAZFhiA.woff2') format('woff2'); } @font-face { font-family: 'Inter'; font-style: normal; font-weight: 400; src: url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZFhjg.woff') format('woff'), url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZFhiA.woff2') format('woff2'); } @font-face { font-family: 'Inter'; font-style: normal; font-weight: 500; src: url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fAZFhjg.woff') format('woff'), url('https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fAZFhiA.woff2') format('woff2'); } @font-face { font-family: 'Paytone One'; font-style: normal; font-weight: 400; src: url('https://fonts.gstatic.com/s/paytoneone/v23/0nksC9P7MfYHj2oFtYm2ChTjgP0.woff') format('woff'), url('https://fonts.gstatic.com/s/paytoneone/v23/0nksC9P7MfYHj2oFtYm2ChTjgPs.woff2') format('woff2'); } }
+ </style>
+</head>
+
+<body class="body pc-font-alt" style="width: 100% !important; min-height: 100% !important; margin: 0 !important; padding: 0 !important; line-height: 1.5; color: #2D3A41; mso-line-height-rule: exactly; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; font-variant-ligatures: normal; text-rendering: optimizeLegibility; -moz-osx-font-smoothing: grayscale; background-color: #ffffff;" bgcolor="#ffffff">
+ <table class="pc-project-body" style="table-layout: fixed; min-width: 600px; background-color:#ffffff;" bgcolor="#ffffff" width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+  <tr>
+   <td align="center" valign="top">
+    <table class="pc-project-container" style="width: 600px; max-width: 600px;" width="600" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+     <tr>
+      <td class="pc-w620-padding-20-0-20-0" style="padding: 20px 0px 20px 0px;" align="left" valign="top">
+       <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="width: 100%;">
+        <tr>
+         <td valign="top">
+          <!-- BEGIN MODULE: Intro -->
+          <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+           <tr>
+            <td class="pc-w620-spacing-0-0-0-0" style="padding: 0px 0px 0px 0px;">
+             <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+              <tr>
+               <td valign="top" class="pc-w620-padding-40-0-0-0" style="padding: 20px 20px 40px 20px; background-color: #56b4e9;" bgcolor="#56b4e9">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="center" valign="top" style="padding: 0px 0px 20px 0px;">
+                   <img src="https://raw.githubusercontent.com/ARCLeeds/event-templator/main/assets/imgs/rc-logo.png" class="pc-w620-width-140 pc-w620-height-auto" width="150" height="45" alt="" style="display: block; border: 0; outline: 0; line-height: 100%; -ms-interpolation-mode: bicubic; width:150px; height: auto; max-width: 100%;" />
+                  </td>
+                 </tr>
+                </table>
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td class="pc-w620-spacing-0-0-4-0" align="center" valign="top" style="padding: 10px 0px 8px 0px;">
+                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="border-collapse: separate; border-spacing: 0; margin-right: auto; margin-left: auto;">
+                    <tr>
+                     <td valign="top" class="pc-w620-padding-0-0-0-0" align="center" style="padding: 0px 0px 0px 0px;">
+                      <div class="pc-font-alt pc-w620-fontSize-16 pc-w620-lineHeight-26" style="line-height: 120%; letter-spacing: 1.9px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 500; font-variant-ligatures: normal; color: #000000; text-transform: uppercase; text-align: center; text-align-last: center;">
+                       <div><span>Title</span>
+                       </div>
+                      </div>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td class="pc-w620-spacing-0-0-16-0" align="center" valign="top" style="padding: 0px 40px 16px 40px;">
+                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" style="border-collapse: separate; border-spacing: 0; margin-right: auto; margin-left: auto;">
+                    <tr>
+                     <td valign="top" class="pc-w620-padding-0-32-0-32" align="center" style="padding: 0px 0px 0px 0px;">
+                      <div class="pc-font-alt pc-w620-fontSize-36px pc-w620-lineHeight-40" style="line-height: 100%; letter-spacing: -0.7px; font-family: 'Paytone One', Arial, Helvetica, sans-serif; font-size: 36px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: center; text-align-last: center;">
+                       <div><span>Short heading</span>
+                       </div>
+                      </div>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="center" valign="top" style="padding: 0px 40px 22px 40px;">
+                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="center" style="border-collapse: separate; border-spacing: 0; margin-right: auto; margin-left: auto;">
+                    <tr>
+                     <td valign="top" align="center" style="padding: 0px 0px 0px 0px;">
+                      <div class="pc-font-alt" style="line-height: 150%; letter-spacing: -0px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 16px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: center; text-align-last: center;">
+                       <div><span style="font-weight: 300;font-style: normal;">This is the body of the advertising. Here you can put any information you want.</span>
+                       </div>
+                      </div>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+               </td>
+              </tr>
+             </table>
+            </td>
+           </tr>
+          </table>
+          <!-- END MODULE: Intro -->
+         </td>
+        </tr>
+        <!-- BEGIN MODULE: Event -->
+        
+        <tr>
+         <td valign="top">
+          <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+           <tr>
+            <td class="pc-w620-spacing-0-0-0-0" style="padding: 10px 0px 0px 0px;">
+             <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation" style="border-collapse: separate; border-spacing: 0px;">
+              <tr>
+               <td valign="top" class="pc-w620-padding-40-0-0-0" style="padding: 20px 20px 20px 20px; border-radius: 10px 10px 10px 10px; border-top: 1px solid #cccccc; border-right: 1px solid #cccccc; border-bottom: 1px solid #cccccc; border-left: 1px solid #cccccc; background-color: #efefef;" bgcolor="#efefef">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="left">
+                   <table class="pc-width-hug pc-w620-gridCollapsed-1" height="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                    <tr class="pc-grid-tr-first pc-grid-tr-last">
+                     <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                      <table width="200px" height="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%; height: 100%;">
+                        <tr>
+                        <td align="center" valign="middle" style="background-color: #0068b1; border-radius: 10px 10px 10px 10px;">
+                         <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="center" valign="top" style="padding: 10px 0px 0px 0px;">
+                               <img src="https://raw.githubusercontent.com/ARCLeeds/event-templator/main/assets/imgs/calendar-w.png" class="" width="38" height="auto" alt="" style="display: block; border: 0; outline: 0; line-height: 100%; -ms-interpolation-mode: bicubic; width:20%; height: auto;" />
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="center" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="center">
+                                  <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 800; font-variant-ligatures: normal; color: #ffffff; text-align: center; text-align-last: center;">
+                                    
+                                      <div><span>20 Feb</span></div>
+                                    
+                                    <div><span>2024</span></div>                                  
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                     <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                      <table width="400px" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%;">
+                       <tr>
+                        <td align="left" valign="top" style="border-radius: 10px 10px 10px 10px;">
+                         <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="left" valign="top">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left" style="border-collapse: separate; border-spacing: 0;">
+                             <tr>
+                              <td valign="top" align="left" style="padding: 10px 10px 0px 10px;">
+                               <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: left; text-align-last: left;">
+                                <div><span style="font-size: 24px;font-weight: 700;font-style: normal;">Event 1</span>
+                                </div>
+                               </div>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="left" style="padding: 10px 0px 0px 10px;">
+                               <table class="pc-width-hug pc-w620-gridCollapsed-1" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                <tr class="pc-grid-tr-first pc-grid-tr-last">
+                                 
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>tag1</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>tag2</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 
+                                 <!-- <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>In-Person</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td> -->
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top" style="padding: 10px 10px 10px 10px;">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="left" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="left">
+                                  <div class="pc-font-alt" style="line-height: 21px; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #333333; text-align: left; text-align-last: left;">
+                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of the event 1.</span>
+                                   </div>
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="right" style="padding: 0px 10px 10px 0px; text-align: right; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-radius: 8px; background-color: #000000; padding: 5px 10px 5px 10px; box-shadow: 0px 0px 0px 0px rgba(0,0,0,1); font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 800; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #efefef; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" href="https://example.com/event1" target="_blank"><span style="display: block;"><span>Read More</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+               </td>
+              </tr>
+             </table>
+            </td>
+           </tr>
+          </table>
+        </td>
+        </tr>
+        
+        <tr>
+         <td valign="top">
+          <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+           <tr>
+            <td class="pc-w620-spacing-0-0-0-0" style="padding: 10px 0px 0px 0px;">
+             <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation" style="border-collapse: separate; border-spacing: 0px;">
+              <tr>
+               <td valign="top" class="pc-w620-padding-40-0-0-0" style="padding: 20px 20px 20px 20px; border-radius: 10px 10px 10px 10px; border-top: 1px solid #cccccc; border-right: 1px solid #cccccc; border-bottom: 1px solid #cccccc; border-left: 1px solid #cccccc; background-color: #efefef;" bgcolor="#efefef">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="left">
+                   <table class="pc-width-hug pc-w620-gridCollapsed-1" height="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                    <tr class="pc-grid-tr-first pc-grid-tr-last">
+                     <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                      <table width="200px" height="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%; height: 100%;">
+                        <tr>
+                        <td align="center" valign="middle" style="background-color: #0068b1; border-radius: 10px 10px 10px 10px;">
+                         <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="center" valign="top" style="padding: 10px 0px 0px 0px;">
+                               <img src="https://raw.githubusercontent.com/ARCLeeds/event-templator/main/assets/imgs/calendar-w.png" class="" width="38" height="auto" alt="" style="display: block; border: 0; outline: 0; line-height: 100%; -ms-interpolation-mode: bicubic; width:20%; height: auto;" />
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="center" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="center">
+                                  <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 800; font-variant-ligatures: normal; color: #ffffff; text-align: center; text-align-last: center;">
+                                    
+                                      <div><span>05 Mar, </span></div>
+                                    
+                                      <div><span>12 Mar</span></div>
+                                    
+                                    <div><span>2024</span></div>                                  
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                     <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                      <table width="400px" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%;">
+                       <tr>
+                        <td align="left" valign="top" style="border-radius: 10px 10px 10px 10px;">
+                         <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="left" valign="top">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left" style="border-collapse: separate; border-spacing: 0;">
+                             <tr>
+                              <td valign="top" align="left" style="padding: 10px 10px 0px 10px;">
+                               <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: left; text-align-last: left;">
+                                <div><span style="font-size: 24px;font-weight: 700;font-style: normal;">Event 2</span>
+                                </div>
+                               </div>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="left" style="padding: 10px 0px 0px 10px;">
+                               <table class="pc-width-hug pc-w620-gridCollapsed-1" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                <tr class="pc-grid-tr-first pc-grid-tr-last">
+                                 
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>tag3</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>tag4</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>tag5</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 
+                                 <!-- <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>In-Person</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td> -->
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top" style="padding: 10px 10px 10px 10px;">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="left" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="left">
+                                  <div class="pc-font-alt" style="line-height: 21px; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #333333; text-align: left; text-align-last: left;">
+                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is a summary of the event 2.</span>
+                                   </div>
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="right" style="padding: 0px 10px 10px 0px; text-align: right; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-radius: 8px; background-color: #000000; padding: 5px 10px 5px 10px; box-shadow: 0px 0px 0px 0px rgba(0,0,0,1); font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 800; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #efefef; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" href="https://example.com/event2" target="_blank"><span style="display: block;"><span>Read More</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+               </td>
+              </tr>
+             </table>
+            </td>
+           </tr>
+          </table>
+        </td>
+        </tr>
+        
+        <!-- END MODULE: Event -->
+        <!-- <tr>
+         <td valign="top"> -->
+          <!-- BEGIN MODULE: Event -->
+          <!-- <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+           <tr>
+            <td class="pc-w620-spacing-0-0-0-0" style="padding: 10px 0px 0px 0px;">
+             <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation" style="border-collapse: separate; border-spacing: 0px;">
+              <tr>
+               <td valign="top" class="pc-w620-padding-40-0-0-0" style="padding: 20px 20px 20px 20px; border-radius: 10px 10px 10px 10px; border-top: 1px solid #cccccc; border-right: 1px solid #cccccc; border-bottom: 1px solid #cccccc; border-left: 1px solid #cccccc; background-color: #efefef;" bgcolor="#efefef">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="left">
+                   <table class="pc-width-hug pc-w620-gridCollapsed-1" height="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                    <tr class="pc-grid-tr-first pc-grid-tr-last">
+                     <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                      <table width="100%" height="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%; height: 100%;">
+                       <tr>
+                        <td align="center" valign="middle" style="background-color: #0068b1; border-radius: 10px 10px 10px 10px;">
+                         <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="center" valign="top" style="padding: 10px 0px 0px 0px;">
+                               <img src="https://cloudfilesdm.com/postcards/image-1717418812636.png" class="" width="38" height="auto" alt="" style="display: block; border: 0; outline: 0; line-height: 100%; -ms-interpolation-mode: bicubic; width:20%; height: auto;" />
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="center" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="center">
+                                  <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 800; font-variant-ligatures: normal; color: #ffffff; text-align: center; text-align-last: center;">
+                                   <div><span>19 April</span>
+                                   </div>
+                                   <div><span>26 April</span>
+                                   </div>
+                                   <div><span>2024</span>
+                                   </div>
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                     <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                      <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0; width: 100%;">
+                       <tr>
+                        <td align="left" valign="top" style="border-radius: 10px 10px 10px 10px;">
+                         <table align="left" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width: 100%;">
+                          <tr>
+                           <td align="left" valign="top">
+                            <table border="0" cellpadding="0" cellspacing="0" role="presentation" align="left" style="border-collapse: separate; border-spacing: 0;">
+                             <tr>
+                              <td valign="top" align="left" style="padding: 10px 10px 0px 10px;">
+                               <div class="pc-font-alt" style="line-height: 140%; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #000000; text-align: left; text-align-last: left;">
+                                <div><span style="font-size: 24px;font-weight: 700;font-style: normal;">Introduction to Python programming</span>
+                                </div>
+                               </div>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td align="left" style="padding: 10px 0px 0px 10px;">
+                               <table class="pc-width-hug pc-w620-gridCollapsed-1" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                <tr class="pc-grid-tr-first pc-grid-tr-last">
+                                 <td class="pc-grid-td-first pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 5px; padding-bottom: 0px; padding-left: 0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>2 Days</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                 <td class="pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="top" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 5px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                                   <tr>
+                                    <td align="left" valign="top">
+                                     <table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                      <tr>
+                                       <td align="left" valign="top">
+                                        <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                                         <tr>
+                                          <th valign="top" align="left" style="text-align: left; font-weight: normal; line-height: 1;">
+                                           <a style="display: inline-block; box-sizing: border-box; border-radius: 5px 5px 5px 5px; background-color: #cccccc; padding: 2px 5px 2px 5px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #000000; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" target="_blank"><span style="display: block;"><span>In-Person</span></span></a>
+                                          </th>
+                                         </tr>
+                                        </table>
+                                       </td>
+                                      </tr>
+                                     </table>
+                                    </td>
+                                   </tr>
+                                  </table>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <td valign="top" style="padding: 10px 10px 10px 10px;">
+                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%" align="left" style="border-collapse: separate; border-spacing: 0;">
+                                <tr>
+                                 <td valign="top" align="left">
+                                  <div class="pc-font-alt" style="line-height: 21px; letter-spacing: -0.2px; font-family: 'Inter', Arial, Helvetica, sans-serif; font-size: 15px; font-weight: normal; font-variant-ligatures: normal; color: #333333; text-align: left; text-align-last: left;">
+                                   <div style="text-align: start; text-align-last: start;"><span style="font-weight: 400;font-style: normal;color: rgb(17, 17, 17);">This is an introduction to programming in Python for people with little or no previous programming experience.</span>
+                                   </div>
+                                  </div>
+                                 </td>
+                                </tr>
+                               </table>
+                              </td>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="left" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="right" style="padding: 0px 10px 10px 0px; text-align: right; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-radius: 8px; background-color: #000000; padding: 5px 10px 5px 10px; box-shadow: 0px 0px 0px 0px rgba(0,0,0,1); font-family: 'Inter', Arial, Helvetica, sans-serif; font-weight: 800; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #efefef; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none;" href="https://designmodo.com/postcards" target="_blank"><span style="display: block;"><span>Read More</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+               </td>
+              </tr>
+             </table>
+            </td>
+           </tr>
+          </table> -->
+          <!-- END MODULE: Event -->
+         <!-- </td>
+        </tr> -->
+        <tr>
+         <td valign="top">
+          <!-- BEGIN MODULE: Footer -->
+          <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+           <tr>
+            <td class="pc-w620-spacing-0-0-0-0" style="padding: 10px 0px 0px 0px;">
+             <table width="100%" border="0" cellspacing="0" cellpadding="0" role="presentation">
+              <tr>
+               <td valign="top" class="pc-w620-padding-40-30-40-30" style="padding: 60px 60px 20px 60px; border-radius: 0px; background-color: #1c3848;" bgcolor="#1c3848">
+                <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                 <tr>
+                  <td align="center" style="padding: 0px 0px 32px 0px;">
+                   <table class="pc-width-hug pc-w620-gridCollapsed-1" align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                    <tr class="pc-grid-tr-first pc-grid-tr-last">
+                     <td class="pc-grid-td-first pc-grid-td-last pc-w620-itemsSpacings-0-30" valign="middle" style="padding-top: 0px; padding-right: 0px; padding-bottom: 0px; padding-left: 0px;">
+                      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse: separate; border-spacing: 0;">
+                       <tr>
+                        <td align="center" valign="top">
+                         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="center" style="padding: 0px 0px 16px 0px; text-align: center; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-top: 2px solid #ffffff; border-right: 2px solid #ffffff; border-bottom: 3px solid #ffffff; border-left: 2px solid #ffffff; border-radius: 500px 500px 500px 500px; background-color: transparent; padding: 10px 82px 10px 82px; width: 300px; font-family: 'Paytone One', Arial, Helvetica, sans-serif; font-weight: normal; font-size: 16px; line-height: 24px; letter-spacing: -0px; color: #ffffff; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none; mso-hide: all;" href="https://arc.leeds.ac.uk/about/team/" target="_blank"><span style="display: block;"><span>The team</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="center" style="padding: 0px 0px 16px 0px; text-align: center; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-top: 2px solid #ffffff; border-right: 2px solid #ffffff; border-bottom: 3px solid #ffffff; border-left: 2px solid #ffffff; border-radius: 500px 500px 500px 500px; background-color: transparent; padding: 10px 70px 10px 70px; width: 300px; font-family: 'Paytone One', Arial, Helvetica, sans-serif; font-weight: normal; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #ffffff; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none; mso-hide: all;" href="https://arcdocs.leeds.ac.uk/welcome.html" target="_blank"><span style="display: block;"><span>ARC3 &amp; ARC4</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                          <tr>
+                           <td align="center" valign="top">
+                            <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+                             <tr>
+                              <th valign="top" align="center" style="padding: 0px 0px 0px 0px; text-align: center; font-weight: normal; line-height: 1;">
+                               <a style="display: inline-block; box-sizing: border-box; border-top: 2px solid #ffffff; border-right: 2px solid #ffffff; border-bottom: 3px solid #ffffff; border-left: 2px solid #ffffff; border-radius: 500px 500px 500px 500px; background-color: transparent; padding: 10px 71px 10px 71px; width: 300px; font-family: 'Paytone One', Arial, Helvetica, sans-serif; font-weight: normal; font-size: 16px; line-height: 24px; letter-spacing: -0.2px; color: #ffffff; vertical-align: top; text-align: center; text-align-last: center; text-decoration: none; -webkit-text-size-adjust: none; mso-hide: all;" href="https://bit.ly/arc-help" target="_blank"><span style="display: block;"><span>Send us a query</span></span></a>
+                              </th>
+                             </tr>
+                            </table>
+                           </td>
+                          </tr>
+                         </table>
+                        </td>
+                       </tr>
+                      </table>
+                     </td>
+                    </tr>
+                   </table>
+                  </td>
+                 </tr>
+                </table>
+               </td>
+              </tr>
+             </table>
+            </td>
+           </tr>
+          </table>
+          <!-- END MODULE: Footer -->
+         </td>
+        </tr>
+        <!-- <tr>
+         <td>
+          <table width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation">
+           <tr>
+            <td align="center" valign="top" style="padding-top: 20px; padding-bottom: 20px; vertical-align: top;">
+             <a href="https://designmodo.com/postcards?uid=MjQ5ODU1&type=footer" target="_blank" style="text-decoration: none; overflow: hidden; border-radius: 2px; display: inline-block;">
+              <img src="https://cloudfilesdm.com/postcards/promo-footer-dark.jpg" width="198" height="46" alt="Made with (o -) postcards" style="width: 198px; height: auto; margin: 0 auto; border: 0; outline: 0; line-height: 100%; -ms-interpolation-mode: bicubic; vertical-align: top;">
+             </a>
+             <img src="https://api-postcards.designmodo.com/tracking/mail/promo?uid=MjQ5ODU1" width="1" height="1" alt="" style="display:none; width: 1px; height: 1px;">
+            </td>
+           </tr>
+          </table>
+         </td>
+        </tr> -->
+       </table>
+      </td>
+     </tr>
+    </table>
+   </td>
+  </tr>
+ </table>
+ <!-- Fix for Gmail on iOS -->
+ <div class="pc-gmail-fix" style="white-space: nowrap; font: 15px courier; line-height: 0;">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+ </div>
+</body>
+
+</html>


### PR DESCRIPTION
Actions in yaml updated to latest versions; runs correctly without warning.

One issue to deal with at a later point (if desired) is that the action fails if the generated html file hasn't changed. Not a problem, but annoying when testing changes and then updating the readme etc; at some point would be good to update this to instead just print out a statement that html build was successful with no changes.